### PR TITLE
refactor : fred API 반환값 제네릭타입 지정

### DIFF
--- a/src/backendApi/fred.ts
+++ b/src/backendApi/fred.ts
@@ -1,3 +1,4 @@
+import { Observation_Type, ObservationResult_Type, OriginSeriess_Type } from '@/types/fredType';
 import axios from 'axios';
 
 interface DataItem {
@@ -5,7 +6,7 @@ interface DataItem {
 	value: number | string;
 }
 
-export const getIndicator = async (seriesId: string) => {
+export const getIndicator = async (seriesId: string): Promise<OriginSeriess_Type> => {
 	try {
 		const response = await axios.get(`/api/indicator?seriesId=${seriesId}`);
 		const data = response.data.seriess[0];
@@ -17,10 +18,11 @@ export const getIndicator = async (seriesId: string) => {
 		} else {
 			console.error('Unexpected Error', error);
 		}
+		throw error;
 	}
 };
 
-export const getIndicators = async (categoryId: number) => {
+export const getIndicators = async (categoryId: number): Promise<OriginSeriess_Type[]> => {
 	try {
 		const response = await axios.get(`/api/category?categoryId=${categoryId}`);
 		return response.data.seriess;
@@ -30,12 +32,12 @@ export const getIndicators = async (categoryId: number) => {
 		} else {
 			console.error('Unexpected Error', error);
 		}
-
-		return [];
+		throw error;
+		// return [];
 	}
 };
 
-export const getChartData = async (seriesId: string) => {
+export const getChartData = async (seriesId: string): Promise<ObservationResult_Type> => {
 	try {
 		const response = await axios.get(`/api/chartValues?seriesId=${seriesId}`);
 		const { realtime_start, realtime_end } = response.data;
@@ -50,12 +52,11 @@ export const getChartData = async (seriesId: string) => {
 		return { realtime_start, realtime_end, dataArray };
 	} catch (error) {
 		console.error('Error fetching data: ', error);
-
-		return {
-			realtime_start: null,
-			realtime_end: null,
-			dataArray: [],
-			error: 'Error fetching data'
-		};
+		throw error;
+		// return {
+		// 	realtime_start: '',
+		// 	realtime_end: '',
+		// 	dataArray: [],
+		// };
 	}
 };

--- a/src/components/chartList/ChartList.tsx
+++ b/src/components/chartList/ChartList.tsx
@@ -4,7 +4,7 @@ import { useQueries } from '@tanstack/react-query';
 import { getChartData, getIndicator } from '@/backendApi/fred';
 import const_queryKey from '@/const/queryKey';
 import LineChart from '../charts/line/LineChart';
-import { SeriessType, Value } from '@/types/fredType';
+import { SeriessType, DateValue_Type } from '@/types/fredType';
 
 interface ChartSwiperProps {
 	seriesIds: string[];
@@ -19,7 +19,7 @@ export default function ChartList({ seriesIds }: ChartSwiperProps) {
 		})),
 		combine: results => {
 			return {
-				valuesArrays: results.map<Value[]>(result => result.data?.dataArray)
+				valuesArrays: results.map<DateValue_Type[]>(result => result.data.dataArray)
 			};
 		}
 	});

--- a/src/components/chartSwiper/ChartSwiper.tsx
+++ b/src/components/chartSwiper/ChartSwiper.tsx
@@ -5,7 +5,7 @@ import { useQueries } from '@tanstack/react-query';
 import { getChartData, getIndicator } from '@/backendApi/fred';
 import const_queryKey from '@/const/queryKey';
 import LineChart from '../charts/line/LineChart';
-import { ChartDataForSwiper, SeriessType, Value } from '@/types/fredType';
+import { ChartDataForSwiper_Type, SeriessType, DateValue_Type } from '@/types/fredType';
 import { Indicator } from '@/types/userType';
 
 interface ChartSwiperProps {
@@ -21,7 +21,7 @@ export default function ChartSwiper({ seriesIds }: ChartSwiperProps) {
 		})),
 		combine: results => {
 			return {
-				valuesArrays: results.map<Value[]>(result => result.data?.dataArray)
+				valuesArrays: results.map<DateValue_Type[]>(result => result.data?.dataArray)
 			};
 		}
 	});

--- a/src/components/charts/line/LineChart.tsx
+++ b/src/components/charts/line/LineChart.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 import clsx from 'clsx';
 import styles from './LineChart.module.scss';
-import { SeriessType, Value } from '@/types/fredType';
+import { SeriessType, DateValue_Type } from '@/types/fredType';
 
 export interface LineChartProps {
 	indicator: SeriessType;
 	children?: React.ReactElement;
 	height?: number;
 	width?: number;
-	values: Value[] | [undefined, undefined];
+	values: DateValue_Type[] | [undefined, undefined];
 	className?: string;
 	seriesId?: string;
 }
@@ -38,15 +38,15 @@ const LineChart = ({ indicator, values, width, height, children, className, seri
 		const marginRight = 40;
 		const marginBottom = 40;
 		const marginLeft = 40;
-		const x = d3.scaleUtc(d3.extent(values as Value[], (value: Value) => value.date) as unknown as [Date, Date], [
-			marginLeft,
-			width - marginRight
-		]);
-		const maxValue = d3.max(values as Value[], (value: Value) => value.value) || 0;
+		const x = d3.scaleUtc(
+			d3.extent(values as DateValue_Type[], (value: DateValue_Type) => value.date) as unknown as [Date, Date],
+			[marginLeft, width - marginRight]
+		);
+		const maxValue = d3.max(values as DateValue_Type[], (value: DateValue_Type) => value.value) || 0;
 		const y = d3.scaleLinear([0, maxValue * 1.3], [height - marginBottom, marginTop]);
 
 		const line = d3
-			.line<Value>()
+			.line<DateValue_Type>()
 			.x(d => x(d.date))
 			.y(d => y(d.value));
 
@@ -89,7 +89,7 @@ const LineChart = ({ indicator, values, width, height, children, className, seri
 			.attr('fill', 'none')
 			.attr('stroke', 'steelblue')
 			.attr('stroke-width', 1.5)
-			.attr('d', line(values as Value[]));
+			.attr('d', line(values as DateValue_Type[]));
 	}, [svgContainerRef]);
 
 	return (

--- a/src/pages/api/chartValues.ts
+++ b/src/pages/api/chartValues.ts
@@ -1,9 +1,9 @@
-import { Observation } from '@/types/fredType';
+import { Observation_Type } from '@/types/fredType';
 import axios from 'axios';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 interface ApiResponse {
-	observations?: Observation[];
+	observations?: Observation_Type[];
 	message?: string;
 }
 

--- a/src/pages/api/indicator.ts
+++ b/src/pages/api/indicator.ts
@@ -1,9 +1,9 @@
-import { Observation } from '@/types/fredType';
+import { Observation_Type } from '@/types/fredType';
 import axios from 'axios';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 type ApiResponse = {
-	observations?: Observation[];
+	observations?: Observation_Type[];
 	message?: string;
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ import ReactPaginate from 'react-paginate';
 import { useRouter } from 'next/router';
 import const_queryKey from '@/const/queryKey';
 import { getIndicators } from '@/backendApi/fred';
-import { CategoryType } from '@/types/fredType';
+import { Category_Type } from '@/types/fredType';
 import { roboto, poppins, frontUrl } from './_app';
 import CategoryWithIsActive from '@/components/categoryWithIsAcitve/CategoryWithIsActive';
 import { useEffect, useState } from 'react';
@@ -24,7 +24,7 @@ import useFavoriteQuery from '@/hooks/useFavoriteQuery';
 
 const DynamicAlertModal = dynamic(() => import('@/components/modals/alertModal/AlertModal'), { ssr: false });
 
-export default function Pages({ interest }: { interest: CategoryType }) {
+export default function Pages({ interest }: { interest: Category_Type }) {
 	const user = useSelector((state: Store) => state.user);
 	const router = useRouter();
 	const dispatch = useDispatch();

--- a/src/types/fredType.ts
+++ b/src/types/fredType.ts
@@ -20,11 +20,30 @@ export type SeriessType = {
 	units_short?: string;
 };
 
+export type OriginSeriess_Type = {
+	id: string;
+	realtime_start: string;
+	realtime_end: string;
+	title: string;
+	observation_start: string;
+	observation_end: string;
+	frequency: string;
+	frequency_short: string;
+	units: string;
+	units_short: string;
+	seasonal_adjustment: string;
+	seasonal_adjustment_short: string;
+	last_updated: string;
+	popularity: number;
+	group_popularity: number;
+	notes?: string;
+};
+
 export interface SeriessWithIsActiveInterface extends SeriessType {
 	isActive: boolean;
 }
 
-export type CategoryType = {
+export type Category_Type = {
 	count: number;
 	limit: number;
 	offset: number;
@@ -35,19 +54,25 @@ export type CategoryType = {
 	sort_order: string;
 };
 
-export type Observation = {
+export type Observation_Type = {
 	date: string;
 	realtime_end: string;
 	realtime_start: string;
 	value: string;
 };
 
-export type Value = {
+export type DateValue_Type = {
 	date: Date;
 	value: number;
 };
 
-export type ChartDataForSwiper = {
+export type ObservationResult_Type = {
+	realtime_start: string;
+	realtime_end: string;
+	dataArray: DateValue_Type[];
+};
+
+export type ChartDataForSwiper_Type = {
 	indicator: SeriessType;
-	values: Value[];
+	values: DateValue_Type[];
 };


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- fred API 반환타입 지정 & 타입명 수정

## PR 요약
- fred.ts에서 제네릭을 사용하여  Promise 타이핑
- fredType.ts 에서 추가된 Type명  컨벤션 적용.(~~_Type)

## ScreenShot (Optional)
