### PR TITLE
Type컨벤션에 맞도록 Type/interface명 수정

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,10 @@
-import { ContextNameWithKey_Type, Favorite_Type, Journal_Type, JwtAndGoogleUserData_Type } from '@/types/backendType';
-import { Context_Type, Indicator_Type } from '@/types/userType';
+import {
+	ContextNameWithKey_Type,
+	Favorite_Type,
+	JournalData_Type,
+	JwtAndGoogleUserData_Type
+} from '@/types/backendType';
+import { Context_Type } from '@/types/userType';
 import axios from 'axios';
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL_LOCAL;
@@ -41,7 +46,7 @@ export const getFavorites = async (userId: number): Promise<Favorite_Type[]> => 
 	}
 };
 
-export const getFavorite = async (userId: number, categoryId: number): Promise<Favorite_Type> => {
+export const getFavorite = async (userId: number, categoryId: number): Promise<Favorite_Type[]> => {
 	try {
 		if (typeof window === 'undefined') {
 			throw new Error('This function can only be used in the client-side');
@@ -117,7 +122,7 @@ export const deleteFavorite = async (userId: number, seriesId: string) => {
 	}
 };
 
-export const addContext = async (userId: number, name: string, customIndicators: Indicator_Type[]) => {
+export const addContext = async (userId: number, name: string, customIndicators: Favorite_Type[]) => {
 	try {
 		if (typeof window === 'undefined') {
 			throw new Error('This function can only be used in the client-side');
@@ -263,7 +268,7 @@ export const deleteContext = async (contextId: number) => {
 	}
 };
 
-export const getContextJournals = async (contextId: number): Promise<Journal_Type[]> => {
+export const getContextJournals = async (contextId: number): Promise<JournalData_Type[]> => {
 	try {
 		if (typeof window === 'undefined') {
 			throw new Error('This function can only be used in the client-side');
@@ -292,7 +297,7 @@ export const getContextJournals = async (contextId: number): Promise<Journal_Typ
 	}
 };
 
-export const addJournal = async (userId: number, contextId: number, journalDataParams: Journal_Type) => {
+export const addJournal = async (userId: number, contextId: number, journalDataParams: JournalParams_Type) => {
 	try {
 		if (typeof window === 'undefined') {
 			throw new Error('This function can only be used in the client-side');

--- a/src/components/cards/indicatorCard/IndicatorCard.tsx
+++ b/src/components/cards/indicatorCard/IndicatorCard.tsx
@@ -2,9 +2,9 @@ import clsx from 'clsx';
 import styles from './IndicatorCard.module.scss';
 import { useRouter } from 'next/router';
 import { cleanString } from '@/utils/cleanString';
-import { Indicator_Type } from '@/types/userType';
+import { Favorite_Type } from '@/types/backendType';
 
-interface IndicatorCardProps extends Indicator_Type {
+interface IndicatorCard_Props extends Favorite_Type {
 	children: React.ReactNode;
 	className?: string;
 }
@@ -28,7 +28,7 @@ export default function IndicatorCard({
 	observation_end,
 	observation_start,
 	className
-}: IndicatorCardProps) {
+}: IndicatorCard_Props) {
 	const router = useRouter();
 	const cleandTitle = title ? cleanString(title) : 'title';
 	const localRoutingUrl = process.env.NEXT_PUBLIC_FRONT_URL_LOCAL;

--- a/src/components/currentContext/CurrentContext.tsx
+++ b/src/components/currentContext/CurrentContext.tsx
@@ -3,10 +3,12 @@ import styles from './CurrentContext.module.scss';
 import const_queryKey from '@/const/queryKey';
 import { getContext, getContextIdsWithNames } from '@/api/backend';
 import { useQuery } from '@tanstack/react-query';
-import { Context_Type, Indicator_Type } from '@/types/userType';
+import { Context_Type } from '@/types/userType';
 import ChartSwiper from '../chartSwiper/ChartSwiper';
 import Journal from '../journalsSection/JournalsSection';
 import ChartList from '../chartList/ChartList';
+import { Favorite_Type } from '@/types/backendType';
+
 interface CurrentContextProps {
 	currentContextId: number;
 }
@@ -19,7 +21,7 @@ export default function CurrentContext({ currentContextId }: CurrentContextProps
 
 	if (isLoading) return <div>Loading...</div>;
 
-	const seriesIds = currentContext?.customIndicators.map((indicator: Indicator_Type) => {
+	const seriesIds = currentContext?.customIndicators.map((indicator: Favorite_Type) => {
 		return indicator.seriesId;
 	});
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -58,7 +58,7 @@ export default function Header() {
 					size='small'
 					header='You need to login!'
 					body='Our service is required to login'
-					leftButtonContent='Cancle'
+					leftButtonContent='Cancel'
 					leftButtonHandler={() => setIsAlertModalOpen(false)}
 					rightButtonContent='Login'
 					rightButtonHandler={() => router.push(`${frontUrl}/login`)}

--- a/src/components/journalsSection/JournalsSection.tsx
+++ b/src/components/journalsSection/JournalsSection.tsx
@@ -9,13 +9,13 @@ import { Store_Type } from '@/types/reduxType';
 import { HiMiniPencilSquare } from 'react-icons/hi2';
 import { CgCloseR } from 'react-icons/cg';
 import { changeDate } from '@/utils/cleanString';
-import { Journal_Type } from '@/types/backendType';
+import { JournalData_Type, JournalParams_Type } from '@/types/backendType';
 
-interface JournalProps {
+interface Journal_Props {
 	contextId: number;
 }
 
-export default function Journal({ contextId }: JournalProps) {
+export default function Journal({ contextId }: Journal_Props) {
 	const userId = useSelector((state: Store_Type) => state.user.id);
 	const [isWrite, setIsWrite] = useState(false);
 	const [journalDataParams, setJournalDataParams] = useState({ title: '', body: '' });
@@ -29,7 +29,7 @@ export default function Journal({ contextId }: JournalProps) {
 		}: {
 			userId: number;
 			contextId: number;
-			journalDataParams: Journal_Type;
+			journalDataParams: JournalParams_Type;
 		}) => addJournal(userId, contextId, journalDataParams),
 		onSuccess() {
 			queryClient.invalidateQueries({
@@ -65,7 +65,7 @@ export default function Journal({ contextId }: JournalProps) {
 	const changeJournalInputData = (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
 		e.preventDefault();
 		const { name, value } = e.target; // e.target에서 name과 value를 추출
-		const newParams: Pick<Journal_Type, 'title' | 'body'> = {
+		const newParams: JournalParams_Type = {
 			...journalDataParams,
 			[name]: value
 		};
@@ -123,7 +123,7 @@ export default function Journal({ contextId }: JournalProps) {
 								<td>Loading...</td>
 							</tr> // 로딩 중임을 알리는 메시지
 						) : contextJournals && contextJournals.length > 0 ? (
-							contextJournals.map((item: Journal_Type, index: number) => (
+							contextJournals.map((item: JournalData_Type, index: number) => (
 								<tr key={item.id + index}>
 									<td>
 										<div>

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -10,12 +10,12 @@ import { useEffect, useState } from 'react';
 import { ContextIdWithName_Type } from '@/types/userType';
 import { RiDeleteBin6Line } from 'react-icons/ri';
 
-interface MenuProps {
+interface Menu_Props {
 	selectedTab: string;
 	setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export default function Menu({ selectedTab, setSelectedTab }: MenuProps) {
+export default function Menu({ selectedTab, setSelectedTab }: Menu_Props) {
 	const tabs = ['Indicators', 'MyContext'];
 	const queryClient = useQueryClient();
 	const [isAccordianOpen, setIsAccordianOpen] = useState(false);

--- a/src/components/modals/makeContextModal/MakeContextModal.tsx
+++ b/src/components/modals/makeContextModal/MakeContextModal.tsx
@@ -3,7 +3,7 @@ import styles from './MakeContextModal.module.scss';
 import ReactDOM from 'react-dom';
 import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { roboto, poppins } from '@/pages/_app';
-import { ContextIdWithName_Type, Indicator_Type, IndicatorWithIsPick_Type } from '@/types/userType';
+import { ContextIdWithName_Type, IndicatorWithIsPick_Type } from '@/types/userType';
 import useFavoriteQuery from '@/hooks/useFavoriteQuery';
 import { changeCategoryIdToName, changeNameToCategoryId } from '@/utils/changeNameToCategoryId';
 import { addContext, getContextIdsWithNames } from '@/api/backend';
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
 import { Store_Type } from '@/types/reduxType';
 import { useMutation, useMutationState, useQuery, useQueryClient } from '@tanstack/react-query';
 import const_queryKey from '@/const/queryKey';
+import { Favorite_Type } from '@/types/backendType';
 
 interface MakeModalProps {
 	isModalOpen: boolean;
@@ -32,8 +33,8 @@ export default function MakeContextModal({ favorites, isModalOpen, setIsModalOpe
 	});
 
 	const addContextMutation = useMutation({
-		mutationFn: (favoritesForContext: Indicator_Type[]) =>
-			addContext(userId, refInput?.current?.value as string, favoritesForContext as Indicator_Type[]),
+		mutationFn: (favoritesForContext: Favorite_Type[]) =>
+			addContext(userId, refInput?.current?.value as string, favoritesForContext as Favorite_Type[]),
 		onSuccess() {
 			queryClient.invalidateQueries({
 				queryKey: [const_queryKey.context]

--- a/src/components/myContext/MyContext.tsx
+++ b/src/components/myContext/MyContext.tsx
@@ -13,12 +13,12 @@ import 'swiper/css';
 import AllContexts from '../allContexts/AllContexts';
 import CurrentContext from '../currentContext/CurrentContext';
 
-interface MyContextTabProps {
+interface MyContextTab_Props {
 	selectedTab: string;
 	setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export default function MyContextTab({ selectedTab, setSelectedTab }: MyContextTabProps) {
+export default function MyContextTab({ selectedTab, setSelectedTab }: MyContextTab_Props) {
 	const userId = useSelector((state: Store_Type) => state.user.id);
 	const [currentContextId, setCurrentContextId] = useState<number | undefined>();
 	const [selectedContext, setSelectedContext] = useState<string>('');

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -3,7 +3,6 @@ import styles from './Morepage.module.scss';
 import dynamic from 'next/dynamic';
 import { Store_Type } from '@/types/reduxType';
 import LineChart from '@/components/charts/line/LineChart';
-import { Indicator_Type } from '@/types/userType';
 import { useRouter } from 'next/router';
 import const_queryKey from '@/const/queryKey';
 import { useSelector } from 'react-redux';
@@ -16,6 +15,7 @@ import { getChartData, getIndicator } from '@/api/fred';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { addFavorite, deleteFavorite, getFavorite } from '@/api/backend';
 import BubblePopButton from '@/components/bubblePopButton/BubblePopButton';
+import { Favorite_Type } from '@/types/backendType';
 
 const DynamicAlertModal = dynamic(() => import('@/components/modals/alertModal/AlertModal'), { ssr: false });
 
@@ -34,6 +34,8 @@ export default function Morepage() {
 	const [chartDatas, setChartDatas] = useState<DataItem[]>([]);
 	const [indicator, setIndicators] = useState<OriginSeriess_Type>({
 		id: '',
+		realtime_start: '',
+		realtime_end: '',
 		title: '',
 		notes: '',
 		observation_start: '',
@@ -86,7 +88,7 @@ export default function Morepage() {
 			return;
 		}
 
-		const isFind = favorite.find((indicator: Indicator_Type) => indicator.seriesId === seriesId);
+		const isFind = favorite?.find((indicator: Favorite_Type) => indicator.seriesId === seriesId);
 
 		if (isFind) {
 			deleteFavoriteMutation.mutate({ userId: user.id, seriesId: seriesId as string });
@@ -141,7 +143,7 @@ export default function Morepage() {
 
 	// save, delete 상황을 확인하는 useEffect
 	useEffect(() => {
-		if (favorite?.some((el: Indicator_Type) => el.seriesId === seriesId)) {
+		if (favorite?.some((el: Favorite_Type) => el.seriesId === seriesId)) {
 			setIsActive(true);
 		} else {
 			setIsActive(false);

--- a/src/types/backendType.ts
+++ b/src/types/backendType.ts
@@ -18,8 +18,14 @@ export type Favorite_Type = Pick<
 	seriesId: string;
 	categoryId: number;
 };
-
-export type Journal_Type = {
+export type FavoriteWithIsPick_Type = Favorite_Type & {
+	isPick: boolean;
+};
+export type JournalParams_Type = {
+	title: string;
+	body: string;
+};
+export type JournalData_Type = {
 	id: number;
 	title: string;
 	body: string;
@@ -36,7 +42,7 @@ export type Context_Type = {
 	id: number;
 	name: string;
 	customIndicators: Favorite_Type[];
-	journals: Journal_Type[];
+	journals: JournalData_Type[];
 	createdAt: Date;
 	updatedAt: Date;
 };

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -1,21 +1,5 @@
-import { Journal_Type } from './backendType';
+import { Favorite_Type, JournalData_Type } from './backendType';
 import { OriginSeriess_Type } from './fredType';
-
-export type Indicator_Type = Pick<
-	OriginSeriess_Type,
-	'title' | 'notes' | 'observation_start' | 'observation_end' | 'frequency' | 'popularity'
-> & {
-	seriesId: string;
-	categoryId: number;
-};
-
-export type Favorite_Type = Pick<
-	OriginSeriess_Type,
-	'frequency' | 'notes' | 'observation_end' | 'observation_start' | 'popularity' | 'title'
-> & {
-	seriesId: string;
-	categoryId: number;
-};
 
 export type User_Type = {
 	isLogin: boolean;
@@ -27,11 +11,11 @@ export type User_Type = {
 	createAt: string;
 };
 
-export type IndicatorWithIsActive_Type = Indicator_Type & {
+export type IndicatorWithIsActive_Type = Favorite_Type & {
 	isActive: boolean;
 };
 
-export type IndicatorWithIsPick_Type = Indicator_Type & {
+export type IndicatorWithIsPick_Type = Favorite_Type & {
 	isPick: boolean;
 };
 
@@ -42,9 +26,9 @@ export type ContextIdWithName_Type = {
 
 export type Context_Type = {
 	createdAt: string;
-	customIndicators: Indicator_Type[];
+	customIndicators: Favorite_Type[];
 	id: number;
-	journal: Journal_Type[];
+	journal: JournalData_Type[];
 	name: string;
 	updatedAt: string;
 };

--- a/src/utils/cleanString.ts
+++ b/src/utils/cleanString.ts
@@ -26,8 +26,8 @@ export const removeSuffix = (title: string, suffix: string) => {
 export const removeComma = (title: string) => {
 	return title.endsWith(',') ? `${title.slice(0, -1).trim()}...` : title;
 };
-export const addEllipsis = (title: string, maxLength: number) => {
-	return title.length > maxLength ? `${title.slice(0, maxLength)}...` : title;
+export const addEllipsis = (text: string, maxLength: number) => {
+	return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
 };
 export const changeDate = (date: string) => {
 	return date.replace('T', ' ').slice(0, -5);


### PR DESCRIPTION
## 브랜치의 목적 및 상황
수립한 Type컨벤션에 맞도록 Type/interface명 수정하기.

## PR 요약
- components디렉토리 기준 currentContext부터 작업 시 수립한 Type컨벤션에 맞도록 Type/interface명 수정
-- Indicator_Type -> Favorite_Type으로 통합변경
-- Journal_Type -> JournalData_Type, JournalParmas_Type으로 분리
-- IndicatorWithIsPick_Type -> FavoriteWithIsPick_Type 으로 수정

## ScreenShot (Optional)
