### PR TITLE
fix: type이름, query이름을 수립한  컨벤션으로 적용

### DIFF
--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -35,7 +35,7 @@ export const addContext = async (userId: number, name: string, customIndicators:
 		}
 	}
 };
-
+//하나의 context에 대한 데이터.
 export const getContext = async (contextId: number): Promise<Context_Type> => {
 	try {
 		if (typeof window === 'undefined') {
@@ -64,8 +64,8 @@ export const getContext = async (contextId: number): Promise<Context_Type> => {
 		throw new Error("Failed to get user's context");
 	}
 };
-
-export const getAllContext_List = async (userId: number): Promise<Context_Type[]> => {
+//MyContext Tab 페이지에서 전체 context 목록을 보여주기 위한 데이터.
+export const getAllContexts_List = async (userId: number): Promise<Context_Type[]> => {
 	try {
 		if (typeof window === 'undefined') {
 			throw new Error('This function can only be used in the client-side');
@@ -93,7 +93,7 @@ export const getAllContext_List = async (userId: number): Promise<Context_Type[]
 		throw new Error("Failed to get user's contexts");
 	}
 };
-
+//전체 Context에 대한 각 context의 id, name가 객체로 담긴 배열 형태의 데이터.
 export const getContextNameWithKey_List = async (userId: number): Promise<ContextNameWithKey_Type[]> => {
 	try {
 		if (typeof window === 'undefined') {

--- a/src/api/favorite.ts
+++ b/src/api/favorite.ts
@@ -1,7 +1,7 @@
 import { backendUrl } from '@/pages/_app';
 import { FavoriteIndicator_Type } from '@/types/favorite';
 import axios from 'axios';
-
+//메인에서 save한 지표 전체 불러오기.
 export const getAllFavorites_List = async (userId: number): Promise<FavoriteIndicator_Type[]> => {
 	try {
 		if (typeof window === 'undefined') {
@@ -25,7 +25,8 @@ export const getAllFavorites_List = async (userId: number): Promise<FavoriteIndi
 		throw new Error("Failed to get user's favorites");
 	}
 };
-
+//각 categoryId에서 save한 지표 리스트
+//categoryId값은 categoryName(['Interest', 'Exchange', 'Consume', 'Production'])이 갖는 id.
 export const getFavoriteCateogry_List = async (
 	userId: number,
 	categoryId: number
@@ -45,6 +46,7 @@ export const getFavoriteCateogry_List = async (
 			}
 		});
 		const favoriteCategory_List = response.data;
+		console.log('favoriteCategory_List: ', favoriteCategory_List);
 		return favoriteCategory_List;
 	} catch (error) {
 		console.error(error);

--- a/src/api/fred.ts
+++ b/src/api/fred.ts
@@ -1,6 +1,6 @@
 import { DateValue_Type, Observation_Type, ObservationResult_Type, Indicator_Type } from '@/types/fred';
 import axios from 'axios';
-
+//하나의 지표를 만들기 위한 데이터 요청.
 export const getIndicator = async (seriesId: string): Promise<Indicator_Type> => {
 	try {
 		const response = await axios.get(`/api/indicator?seriesId=${seriesId}`);
@@ -16,10 +16,11 @@ export const getIndicator = async (seriesId: string): Promise<Indicator_Type> =>
 		throw error;
 	}
 };
-
+//각 카테고리 fred에서 제공하는 인디케이터 목록을 불러오는 데이터
 export const getCategory_List = async (categoryId: number): Promise<Indicator_Type[]> => {
 	try {
 		const response = await axios.get(`/api/category?categoryId=${categoryId}`);
+		console.log('response.data.seriess: ', response.data.seriess);
 		return response.data.seriess;
 	} catch (error) {
 		if (axios.isAxiosError(error)) {
@@ -31,7 +32,7 @@ export const getCategory_List = async (categoryId: number): Promise<Indicator_Ty
 		return [];
 	}
 };
-
+//지표의 Date 데이터
 export const getChartData = async (seriesId: string): Promise<ObservationResult_Type> => {
 	try {
 		const response = await axios.get(`/api/chartValues?seriesId=${seriesId}`);

--- a/src/api/journal.ts
+++ b/src/api/journal.ts
@@ -2,7 +2,7 @@ import { backendUrl } from '@/pages/_app';
 import { JournalData_Type, JournalParams_Type } from '@/types/journal';
 import axios from 'axios';
 
-export const getContextJournals = async (contextId: number): Promise<JournalData_Type[]> => {
+export const getContextJournal_List = async (contextId: number): Promise<JournalData_Type[]> => {
 	try {
 		if (typeof window === 'undefined') {
 			throw new Error('This function can only be used in the client-side');

--- a/src/components/allContexts/AllContexts.tsx
+++ b/src/components/allContexts/AllContexts.tsx
@@ -7,17 +7,17 @@ import { Store_Type } from '@/types/redux';
 import { addEllipsis, changeDate } from '@/utils/cleanString';
 import { FaPlus } from 'react-icons/fa6';
 import { Context_Type } from '@/types/context';
-import { getAllContext_List } from '@/api/context';
+import { getAllContexts_List } from '@/api/context';
 
-interface AllContexts {
+interface AllContexts_Props {
 	selectedContext: string;
 	setSelectedContext: React.Dispatch<React.SetStateAction<string>>;
 }
-export default function AllContexts({ selectedContext, setSelectedContext }: AllContexts) {
+export default function AllContexts({ selectedContext, setSelectedContext }: AllContexts_Props) {
 	const userId = useSelector((store: Store_Type) => store.user.id);
 	const { data: allContexts, isLoading: isAllContextsLoading } = useQuery<Context_Type[]>({
 		queryKey: [const_queryKey.context, 'all'],
-		queryFn: () => getAllContext_List(userId)
+		queryFn: () => getAllContexts_List(userId)
 	});
 
 	if (isAllContextsLoading) {

--- a/src/components/bubblePopButton/BubblePopButton.tsx
+++ b/src/components/bubblePopButton/BubblePopButton.tsx
@@ -1,13 +1,13 @@
 import clsx from 'clsx';
 import styles from './BubblePopButton.module.scss';
 
-interface BubblePopButtonProps {
+interface BubblePopButton_Props {
 	children?: React.ReactNode;
 	className?: string;
 	clickHandler: () => void;
 }
 
-export default function BubblePopButton({ children, className, clickHandler: onClick }: BubblePopButtonProps) {
+export default function BubblePopButton({ children, className, clickHandler: onClick }: BubblePopButton_Props) {
 	const bubblePop = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
 		event.stopPropagation();
 	};

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -4,7 +4,7 @@ import { Indicator_Type } from '@/types/fred';
 import IndicatorCard from '../cards/indicatorCard/IndicatorCard';
 import BubblePopButton from '../bubblePopButton/BubblePopButton';
 
-interface CategoryInterface {
+interface Category_Props {
 	categoryData: Indicator_Type[];
 	currentPage: number;
 	itemsPerPage: number;
@@ -18,7 +18,7 @@ export default function Category({
 	itemsPerPage,
 	categoryId,
 	setIsAlertModalOpen
-}: CategoryInterface) {
+}: Category_Props) {
 	return (
 		<figure className={clsx(styles.Category)}>
 			{categoryData

--- a/src/components/categoryTab/CategoryTab.tsx
+++ b/src/components/categoryTab/CategoryTab.tsx
@@ -2,12 +2,12 @@ import clsx from 'clsx';
 import styles from './Category.module.scss';
 import { useState } from 'react';
 
-interface CategoryTab {
+interface CategoryTab_Props {
 	categoryNames: string[];
 }
 
 /** categoryNames 배열을 전달하면 tab 기능을 제공한다. */
-export default function CategoryTab({ categoryNames }: CategoryTab) {
+export default function CategoryTab({ categoryNames }: CategoryTab_Props) {
 	const [categoryIndex, setCategoryIndex] = useState(0);
 	return (
 		<div className={clsx(styles.CategoryTab)}>

--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
@@ -14,7 +14,7 @@ import useFavoriteMutation from '@/hooks/useFavoriteMutation';
 import { getFavoriteCateogry_List } from '@/api/favorite';
 import { FavoriteIndicatorWithIsActive_Type, FavoriteIndicator_Type } from '@/types/favorite';
 
-interface CategoryWithIsActive_Intercae {
+interface CategoryWithIsActive_Props {
 	categoryData: Indicator_Type[];
 	currentPage: number;
 	itemsPerPage: number;
@@ -26,7 +26,7 @@ export default function CategoryWithIsActive({
 	currentPage,
 	itemsPerPage,
 	categoryId
-}: CategoryWithIsActive_Intercae) {
+}: CategoryWithIsActive_Props) {
 	const user = useSelector((state: Store_Type) => state.user);
 	const [categoryWithIsActive, setCategoryWithActive] = useState<FavoriteIndicatorWithIsActive_Type[]>([]);
 

--- a/src/components/chartDescription/ChartDescription.tsx
+++ b/src/components/chartDescription/ChartDescription.tsx
@@ -2,12 +2,12 @@ import clsx from 'clsx';
 import styles from './ChartDescription.module.scss';
 import { Indicator_Type } from '@/types/fred';
 
-interface ChartDescriptionProps {
+interface ChartDescription_Props {
 	indicator: Indicator_Type;
 	children?: React.ReactNode;
 }
 
-export default function ChartDescription({ indicator, children }: ChartDescriptionProps) {
+export default function ChartDescription({ indicator, children }: ChartDescription_Props) {
 	return (
 		<div className={clsx(styles.ChartDescription)}>
 			<h3>{indicator.title}</h3>

--- a/src/components/chartList/ChartList.tsx
+++ b/src/components/chartList/ChartList.tsx
@@ -6,12 +6,12 @@ import const_queryKey from '@/const/queryKey';
 import LineChart from '../charts/line/LineChart';
 import { DateValue_Type, Indicator_Type } from '@/types/fred';
 
-interface ChartSwiperProps {
+interface ChartSwiper_Props {
 	seriesIds: string[];
 }
 
 /** context data 가 넘어왔을 때 */
-export default function ChartList({ seriesIds }: ChartSwiperProps) {
+export default function ChartList({ seriesIds }: ChartSwiper_Props) {
 	const queryChartValues = useQueries({
 		queries: seriesIds.map(seriesId => ({
 			queryKey: [const_queryKey.context, seriesId],
@@ -19,7 +19,7 @@ export default function ChartList({ seriesIds }: ChartSwiperProps) {
 		})),
 		combine: results => {
 			return {
-				valuesArrays: results.map<DateValue_Type[]>(result => result.data.dataArray)
+				valuesArrays: results.map<DateValue_Type[]>(result => result.data?.dataArray || [])
 			};
 		}
 	});

--- a/src/components/chartSwiper/ChartSwiper.tsx
+++ b/src/components/chartSwiper/ChartSwiper.tsx
@@ -8,12 +8,12 @@ import LineChart from '../charts/line/LineChart';
 import { ChartDataForSwiper_Type, SeriessType, DateValue_Type } from '@/types/fred';
 import { Indicator } from '@/types/userType';
 
-interface ChartSwiperProps {
+interface ChartSwiper_Props {
 	seriesIds: string[];
 }
 
 /** context data 가 넘어왔을 때 */
-export default function ChartSwiper({ seriesIds }: ChartSwiperProps) {
+export default function ChartSwiper({ seriesIds }: ChartSwiper_Props) {
 	const queryChartValues = useQueries({
 		queries: seriesIds.map(seriesId => ({
 			queryKey: [const_queryKey.context, seriesId],

--- a/src/components/charts/line/LineChart.tsx
+++ b/src/components/charts/line/LineChart.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import styles from './LineChart.module.scss';
 import { Indicator_Type, DateValue_Type } from '@/types/fred';
 
-export interface LineChartProps {
+export interface LineChart_Props {
 	indicator: Indicator_Type;
 	children?: React.ReactElement;
 	height?: number;
@@ -20,7 +20,7 @@ export interface LineChartProps {
  * @height [x]vh
  * @width [y]%
  */
-const LineChart = ({ indicator, values, width, height, children, className, seriesId }: LineChartProps) => {
+const LineChart = ({ indicator, values, width, height, children, className, seriesId }: LineChart_Props) => {
 	const svgRef = useRef<SVGSVGElement>(null);
 	const svgContainerRef = useRef<HTMLDivElement>(null);
 	const widthStyle = {

--- a/src/components/currentContext/CurrentContext.tsx
+++ b/src/components/currentContext/CurrentContext.tsx
@@ -9,11 +9,11 @@ import { Context_Type } from '@/types/context';
 import { getContext } from '@/api/context';
 import { FavoriteIndicator_Type } from '@/types/favorite';
 
-interface CurrentContextProps {
+interface CurrentContext_Props {
 	currentContextId: number;
 }
 
-export default function CurrentContext({ currentContextId }: CurrentContextProps) {
+export default function CurrentContext({ currentContextId }: CurrentContext_Props) {
 	const { data: currentContext, isLoading } = useQuery<Context_Type>({
 		queryKey: [const_queryKey.context, currentContextId],
 		queryFn: () => getContext(currentContextId)

--- a/src/components/dashheader/DashHeader.tsx
+++ b/src/components/dashheader/DashHeader.tsx
@@ -4,11 +4,11 @@ import { Store_Type } from '@/types/redux';
 import { useSelector } from 'react-redux';
 import Image from 'next/image';
 
-interface DashboardProp {
+interface Dashboard_Prop {
 	selectedTab: string;
 }
 
-export default function DashHeader({ selectedTab }: DashboardProp) {
+export default function DashHeader({ selectedTab }: Dashboard_Prop) {
 	const user = useSelector((state: Store_Type) => state.user);
 	const profileImageUrl = user.picture_url;
 	return (

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -9,10 +9,6 @@ import { logout } from '@/actions/actions';
 import AlertModal from '../modals/alertModal/AlertModal';
 import { Store_Type } from '@/types/redux';
 
-interface HeaderProps {
-	children: React.ReactNode;
-}
-
 const poppins = Poppins({
 	subsets: ['latin'],
 	weight: ['300', '400', '500'],

--- a/src/components/indicatorsTab/IndicatorsTab.tsx
+++ b/src/components/indicatorsTab/IndicatorsTab.tsx
@@ -32,11 +32,11 @@ export default function IndicatorsTab() {
 
 	const { deleteFavoriteMutationAll } = useFavoriteMutation();
 	const categoryId = changeNameToCategoryId(categoryNames[categoryIndex]);
-	const { allFavorites } = useFavoriteQuery();
-
+	const { allFavorites_List } = useFavoriteQuery();
+	//allFavorite_List
 	useEffect(() => {
 		if (favoritesWithPick.length) {
-			const updated = allFavorites?.map((favorite: FavoriteIndicator_Type) => {
+			const updated = allFavorites_List?.map((favorite: FavoriteIndicator_Type) => {
 				const prev = favoritesWithPick.find(
 					(prevFavorites: FavoriteIndicatorWithIsPick_Type) => prevFavorites.seriesId === favorite.seriesId
 				);
@@ -53,7 +53,7 @@ export default function IndicatorsTab() {
 			updated && setFavoritesWithPick(updated);
 			return;
 		}
-		const updated = allFavorites?.map((favorite: FavoriteIndicator_Type) => {
+		const updated = allFavorites_List?.map((favorite: FavoriteIndicator_Type) => {
 			return {
 				...favorite,
 				isPick: false
@@ -61,7 +61,7 @@ export default function IndicatorsTab() {
 		});
 
 		updated && setFavoritesWithPick(updated);
-	}, [allFavorites]);
+	}, [allFavorites_List]);
 	const curFavorites = favoritesWithPick?.filter(
 		(favorite: FavoriteIndicator_Type) => favorite?.categoryId == categoryId
 	);

--- a/src/components/journalsSection/JournalsSection.tsx
+++ b/src/components/journalsSection/JournalsSection.tsx
@@ -9,7 +9,7 @@ import { HiMiniPencilSquare } from 'react-icons/hi2';
 import { CgCloseR } from 'react-icons/cg';
 import { changeDate } from '@/utils/cleanString';
 import { JournalData_Type, JournalParams_Type } from '@/types/journal';
-import { addJournal, getContextJournals } from '@/api/journal';
+import { addJournal, getContextJournal_List } from '@/api/journal';
 
 interface Journal_Props {
 	contextId: number;
@@ -42,19 +42,9 @@ export default function Journal({ contextId }: Journal_Props) {
 		}
 	});
 
-	const makeJournal = () => {
-		if (journalDataParams.body) {
-			addJournalMutation.mutate({ userId, contextId, journalDataParams });
-		} else {
-			alert('모두 작성해주세요.');
-		}
-
-		setIsWrite(false);
-	};
-
-	const { data: contextJournals, isLoading: isContextJournalsLoading } = useQuery({
+	const { data: contextJournal_List, isLoading: isContextJournalListLoading } = useQuery({
 		queryKey: [const_queryKey.journal, contextId],
-		queryFn: () => getContextJournals(contextId as number)
+		queryFn: () => getContextJournal_List(contextId as number)
 	});
 
 	const toggleJournalFormButton = (e: React.FormEvent<HTMLSpanElement>) => {
@@ -72,18 +62,23 @@ export default function Journal({ contextId }: Journal_Props) {
 		setJournalDataParams(newParams);
 	};
 
-	const registJournal = (e: React.FormEvent<HTMLFormElement>) => {
+	const requestAddJournal = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		makeJournal();
+		if (journalDataParams.body) {
+			addJournalMutation.mutate({ userId, contextId, journalDataParams });
+			setIsWrite(false);
+		} else {
+			alert('모두 작성해주세요.');
+		}
 	};
 	useEffect(() => {
 		// journal 데이터가 있고 항목이 하나 이상 있는 경우 isOpen을 true로 설정
-		if (contextJournals && contextJournals.length > 0) {
+		if (contextJournal_List && contextJournal_List.length > 0) {
 			setIsWrite(false);
 		} else {
 			setIsWrite(true); // 그렇지 않으면 false로 설정
 		}
-	}, [contextJournals]);
+	}, [contextJournal_List]);
 
 	return (
 		<div className={clsx(styles.Journal)}>
@@ -95,7 +90,7 @@ export default function Journal({ contextId }: Journal_Props) {
 			</section>
 
 			{isWrite && (
-				<form onSubmit={registJournal}>
+				<form onSubmit={requestAddJournal}>
 					<label htmlFor='title'>Title</label>
 					<input
 						type='text'
@@ -118,12 +113,12 @@ export default function Journal({ contextId }: Journal_Props) {
 			<div className={clsx(styles.JournalTable)}>
 				<table>
 					<tbody>
-						{isContextJournalsLoading ? (
+						{isContextJournalListLoading ? (
 							<tr>
 								<td>Loading...</td>
 							</tr> // 로딩 중임을 알리는 메시지
-						) : contextJournals && contextJournals.length > 0 ? (
-							contextJournals.map((item: JournalData_Type, index: number) => (
+						) : contextJournal_List && contextJournal_List.length > 0 ? (
+							contextJournal_List.map((item: JournalData_Type, index: number) => (
 								<tr key={item.id + index}>
 									<td>
 										<div>

--- a/src/components/modals/makeContextModal/MakeContextModal.tsx
+++ b/src/components/modals/makeContextModal/MakeContextModal.tsx
@@ -3,38 +3,36 @@ import styles from './MakeContextModal.module.scss';
 import ReactDOM from 'react-dom';
 import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { roboto, poppins } from '@/pages/_app';
-import { ContextIdWithName_Type, IndicatorWithIsPick_Type } from '@/types/userType';
-import useFavoriteQuery from '@/hooks/useFavoriteQuery';
-import { changeCategoryIdToName, changeNameToCategoryId } from '@/utils/changeNameToCategoryId';
-import { addContext, getContextIdsWithNames } from '@/api/backend';
 import { useSelector } from 'react-redux';
 import { Store_Type } from '@/types/redux';
 import { useMutation, useMutationState, useQuery, useQueryClient } from '@tanstack/react-query';
 import const_queryKey from '@/const/queryKey';
-import { Favorite_Type } from '@/types/backendType';
+import { FavoriteIndicatorWithIsPick_Type, FavoriteIndicator_Type } from '@/types/favorite';
+import { addContext, getContextNameWithKey_List } from '@/api/context';
+import { ContextNameWithKey_Type } from '@/types/context';
 
 interface MakeModalProps {
 	isModalOpen: boolean;
 	setIsModalOpen: Dispatch<SetStateAction<boolean>>;
 	children?: React.ReactNode;
-	favorites: IndicatorWithIsPick_Type[];
+	favorites: FavoriteIndicatorWithIsPick_Type[];
 }
 
 export default function MakeContextModal({ favorites, isModalOpen, setIsModalOpen, children }: MakeModalProps) {
 	const userId = useSelector((state: Store_Type) => state.user.id);
-	const [selectedFavorites, setSelectedFavorites] = useState<IndicatorWithIsPick_Type[]>();
+	const [selectedFavorites, setSelectedFavorites] = useState<FavoriteIndicatorWithIsPick_Type[]>();
 	const refInput = useRef<HTMLInputElement>(null);
 	const queryClient = useQueryClient();
 
 	// 나중에 훅으로 처리할 부분
 	const { data: contextNamesWithKey, isLoading } = useQuery({
 		queryKey: [const_queryKey.context, 'names'],
-		queryFn: () => getContextIdsWithNames(userId)
+		queryFn: () => getContextNameWithKey_List(userId)
 	});
 
 	const addContextMutation = useMutation({
-		mutationFn: (favoritesForContext: Favorite_Type[]) =>
-			addContext(userId, refInput?.current?.value as string, favoritesForContext as Favorite_Type[]),
+		mutationFn: (favoritesForContext: FavoriteIndicator_Type[]) =>
+			addContext(userId, refInput?.current?.value as string, favoritesForContext as FavoriteIndicator_Type[]),
 		onSuccess() {
 			queryClient.invalidateQueries({
 				queryKey: [const_queryKey.context]
@@ -53,7 +51,7 @@ export default function MakeContextModal({ favorites, isModalOpen, setIsModalOpe
 		if (
 			refInput.current &&
 			favoritesForContext &&
-			!contextNamesWithKey?.some((context: ContextIdWithName_Type) => refInput?.current?.value === context.name)
+			!contextNamesWithKey?.some((context: ContextNameWithKey_Type) => refInput?.current?.value === context.name)
 		) {
 			addContextMutation.mutate(favoritesForContext);
 		} else {

--- a/src/hooks/useFavoriteQuery.tsx
+++ b/src/hooks/useFavoriteQuery.tsx
@@ -1,4 +1,4 @@
-import { getFavorite, getFavorites } from '@/api/backend';
+import { getAllFavorites_List, getFavoriteCateogry_List } from '@/api/favorite';
 import const_queryKey from '@/const/queryKey';
 import { Store_Type } from '@/types/redux';
 import { useQuery } from '@tanstack/react-query';
@@ -12,18 +12,18 @@ import { useSelector } from 'react-redux';
 export default function useFavoriteQuery(categoryId?: number) {
 	const user = useSelector((state: Store_Type) => state.user);
 
-	const { data: allFavorites, isSuccess: isAllFavoritesExist } = useQuery({
+	const { data: allFavorites_List, isSuccess: isAllFavoritesExist } = useQuery({
 		queryKey: [const_queryKey.favorite],
-		queryFn: () => getFavorites(user.id)
+		queryFn: () => getAllFavorites_List(user.id)
 	});
 
 	const { data: selectedFavorites, isSuccess: isSelectedFavoritesExist } = useQuery({
 		queryKey: [const_queryKey.favorite, categoryId],
-		queryFn: () => getFavorite(user.id, categoryId ?? 0),
+		queryFn: () => getFavoriteCateogry_List(user.id, categoryId ?? 0),
 		enabled: !!categoryId
 	});
 
-	return !!categoryId ? { selectedFavorites, isSelectedFavoritesExist } : { allFavorites, isAllFavoritesExist };
+	return !!categoryId ? { selectedFavorites, isSelectedFavoritesExist } : { allFavorites_List, isAllFavoritesExist };
 }
 
 /* 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,6 @@ import { changeNameToCategoryId } from '@/utils/changeNameToCategoryId';
 import { useDispatch, useSelector } from 'react-redux';
 import { roboto, poppins, frontUrl } from './_app';
 import { categoryNames } from './_app';
-import useFavoriteQuery from '@/hooks/useFavoriteQuery';
 import { User_Type } from '@/types/user';
 
 const DynamicAlertModal = dynamic(() => import('@/components/modals/alertModal/AlertModal'), { ssr: false });


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- type이름, query이름을 수립한  컨벤션으로 적용


## PR 요약
- 복수형 → 단수형_List
- all+복수형 → all+복수형_List
- 컴포넌트 Props의 interface명 →  컴포넌트_Props로 수정
- 각 api에 요청하는 데이터에 대한 주석추가
- 안쓰이는 import 제거

## ScreenShot (Optional)
