### PR TITLE
fix: Indicator 에서 seriesId 를 갖고오지 않음

### DIFF
--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
@@ -45,7 +45,7 @@ export default function CategoryWithIsActive({
 	useEffect(() => {
 		if (categoryData && isFavoriteExist && favorite) {
 			const favoriteCategoryWithIsActive = categoryData.map((indicator: Indicator_Type) => {
-				const { frequency, notes, observation_end, observation_start, popularity, title } = indicator;
+				const { id: seriesId, frequency, notes, observation_end, observation_start, popularity, title } = indicator;
 				return {
 					frequency,
 					notes,
@@ -53,7 +53,7 @@ export default function CategoryWithIsActive({
 					observation_start,
 					popularity,
 					title,
-					seriesId: '',
+					seriesId,
 					categoryId: categoryId,
 					isActive: false
 				};


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- addFavorite 이 제대로 실행되지 않는 문제가 발생함

## PR 요약
- CateogoryWithIsAcitve 에서 seriesId 를 받아오도록 변경

## ScreenShot (Optional)
