### PR TITLE
feat: SEO컴포넌트 생성

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+	reactStrictMode: true,
+	images: {
+		formats: ['image/avif', 'image/webp']
+	}
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
-		"@next/font": "^14.1.0",
 		"@tanstack/react-query": "^5.20.2",
 		"@tanstack/react-query-devtools": "^5.24.8",
 		"@types/d3": "^7.4.3",

--- a/src/components/SEO/SEO.tsx
+++ b/src/components/SEO/SEO.tsx
@@ -1,0 +1,20 @@
+import Head from 'next/head';
+interface SEO_Props {
+	title: string;
+}
+export default function SEO({ title }: SEO_Props) {
+	return (
+		<Head>
+			<title>{`Economic Context | ${title}`}</title>
+			<meta
+				name='description'
+				content='내가 원하는 경제지표를 편리하게 관리하고, 나의 일지를 작성할 수 있습니다. 로그인으로 시작하세요.'
+			/>
+			<meta charSet='UTF-8' />
+			<meta property='og:title' content={`Economic Context : 경제지표를 더 쉽게 관리하자!`} />
+			<meta property='og:type' content='website' />
+			<meta property='og:url' content='https://localhost:3000' />
+			<meta name='keywords' content='economic, EconomicContext, indicator'></meta>
+		</Head>
+	);
+}

--- a/src/pages/login/Login.module.scss
+++ b/src/pages/login/Login.module.scss
@@ -22,13 +22,10 @@
 		justify-content: space-between;
 
 		.logo {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			justify-content: center;
 			cursor: pointer;
 
-			div {
+			p {
+				text-align: center;
 				font-size: 60px;
 				font-weight: 400;
 				letter-spacing: 5px;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,8 +1,11 @@
 import clsx from 'clsx';
 import styles from './Login.module.scss';
+import loginBackground from '../../../public/loginBackground.jpg';
 import Image from 'next/image';
 import { roboto, poppins } from '../_app';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
+import Head from 'next/head';
 
 export default function Login() {
 	const router = useRouter();
@@ -10,33 +13,43 @@ export default function Login() {
 	const redirectUrl =
 		process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URL || 'https://dev-economic-context.vercel.app/google-callback';
 
-	const moveToHomepage = () => router.push('/');
-
-	const googleLogin = () => {
-		const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${encodeURIComponent(
-			redirectUrl
-		)}&response_type=code&scope=email profile`;
-		router.push(url);
-	};
-
 	return (
 		<div className={clsx(styles.Login, poppins.variable, roboto.variable)}>
+			<Head>
+				<title>{`login page | Economic Context`}</title>
+				<meta property='og:title' content='login page | Economic Context' />
+				<meta property='og:type' content='website' />
+				<meta
+					name='description'
+					content='경제지표를 편리하게 저장해두고, 나의 일지를 작성할 수 있습니다. 로그인으로 시작하세요.'
+				/>
+				<meta property='og:url' content='https://localhost:3000' />
+			</Head>
 			<Image
 				className={clsx(styles.background)}
-				src='/loginBackground.jpg'
+				src={loginBackground}
 				alt='login-background'
-				layout='fill'
-				objectFit='cover'
+				quality={100}
+				fill
+				style={{ objectFit: 'cover' }}
+				placeholder='blur' //사용자 경험을 향상(이미지 최적화x)
+				priority
 			/>
 			<div className={clsx(styles.wrap)}>
-				<h1 className={clsx(styles.logo)} onClick={moveToHomepage}>
-					<div>ECONOMIC</div>
-					<div>CONTEXT</div>
-				</h1>
+				<Link href={'/'} className={clsx(styles.logo)}>
+					<p>
+						ECONOMIC <br />
+						CONTEXT
+					</p>
+				</Link>
 				<div className={clsx(styles.buttonWrap)}>
-					<div className={clsx(styles.loginButton)} onClick={googleLogin}>
+					<Link
+						href={`https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${encodeURIComponent(
+							redirectUrl
+						)}&response_type=code&scope=email profile`}
+						className={clsx(styles.loginButton)}>
 						<span>Google Login</span>
-					</div>
+					</Link>
 					<span className={clsx(styles.terms)}>Please agree to the Terms of Use of Economic-Context</span>
 				</div>
 			</div>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { roboto, poppins } from '../_app';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import Head from 'next/head';
+import SEO from '@/components/SEO/SEO';
 
 export default function Login() {
 	const router = useRouter();
@@ -15,16 +15,7 @@ export default function Login() {
 
 	return (
 		<div className={clsx(styles.Login, poppins.variable, roboto.variable)}>
-			<Head>
-				<title>{`login page | Economic Context`}</title>
-				<meta property='og:title' content='login page | Economic Context' />
-				<meta property='og:type' content='website' />
-				<meta
-					name='description'
-					content='경제지표를 편리하게 저장해두고, 나의 일지를 작성할 수 있습니다. 로그인으로 시작하세요.'
-				/>
-				<meta property='og:url' content='https://localhost:3000' />
-			</Head>
+			<SEO title='Login' />
 			<Image
 				className={clsx(styles.background)}
 				src={loginBackground}


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- SEO를 위한 재사용 컴포넌트 생성.


## PR 요약
- page디렉토리에 있는 페이지마다 SEO컴포넌트를 import 합니다
- 각 페이지의 title을 props로 넘겨줍니다.

## ScreenShot (Optional)
아래 이미지는 로그인페이지에 SEO컴포넌트를 적용한 결과입니다. before -> after
![image](https://github.com/Jangwoohyeok123/Economic-Context/assets/70941333/8c15b72c-31d6-411d-a1fb-ed8efc55d569)
