### PR TITLE
fix: category.length > 0 => typeof (category.length / indicatorsPerPa…

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -103,7 +103,7 @@ export default function Home({ interest, exchange, production, consume }: Home_P
 						setIsAlertModalOpen={setIsAlertModalOpen}
 					/>
 				)}
-				{category && category.length > 0 && (
+				{category && typeof (category.length / indicatorsPerPage.current) === 'number' && (
 					<ReactPaginate
 						pageCount={Math.ceil(category.length / indicatorsPerPage.current)}
 						previousAriaLabel='Prev'


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- pagination 에러잡기 

## PR 요약
- undefined 에러잡기 위해 typeof 사용

## ScreenShot (Optional)
