### PR TITLE
style: Indicator tab 스타일링

### DIFF
--- a/src/components/indicatorsTab/IndicatorsTab.module.scss
+++ b/src/components/indicatorsTab/IndicatorsTab.module.scss
@@ -2,7 +2,9 @@
 .IndicatorsTab {
 	width: 100%;
 	padding: var.$tabPagePadding;
-
+	padding-bottom: 0;
+	// nav: 70px + tabPagePaddingTop: 30px + header: 60px +
+	// section + footer = 100vh - 160px;
 	nav {
 		display: flex;
 		gap: 20px;
@@ -26,7 +28,7 @@
 		display: grid;
 		width: 100%;
 		grid-template-columns: 30% 30% 30%;
-		grid-template-rows: 70vh;
+		grid-template-rows: calc(100vh - 164px - 12vh);
 		justify-content: space-between;
 		align-items: center;
 		row-gap: 20px;
@@ -95,7 +97,8 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center; /* 요소들을 수직 방향으로 중앙에 배치 */
-		padding-top: 50px;
+		height: 10vh;
+		padding-top: 5px;
 
 		.item {
 			width: 33%;
@@ -126,18 +129,28 @@
 
 @media screen and (max-width: var.$tablet) {
 	.IndicatorsTab {
+		padding: var.$tabPagePadding;
 		.favorites {
 			grid-template-columns: 48% 48%;
-			grid-template-rows: 60vh;
+			grid-auto-rows: 60vh;
+		}
+
+		.footer {
+			padding-top: 10px;
 		}
 	}
 }
 
 @media screen and (max-width: var.$mobile) {
 	.IndicatorsTab {
+		padding: var.$tabPagePadding;
 		.favorites {
 			grid-template-columns: 100%;
-			grid-template-rows: 50vh;
+			grid-auto-rows: 50vh;
+		}
+
+		.footer {
+			padding-top: 10px;
 		}
 	}
 }

--- a/src/components/indicatorsTab/IndicatorsTab.tsx
+++ b/src/components/indicatorsTab/IndicatorsTab.tsx
@@ -40,7 +40,7 @@ export default function IndicatorsTab() {
 					? {
 							...favoriteIndicator,
 							isPick: prev.isPick
-					  }
+				}
 					: {
 							...favoriteIndicator,
 							isPick: false


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- [x] IndicatorTab 페이지 초기 렌더링 시 pagination, make 버튼 모든 기기에서 보이도록 수정

## PR 요약
- [x] 첫 페이지에 스크롤이 나오지 않도록 만듦

## ScreenShot (Optional)
- 아래 사진은 스크롤이 사라진 페이지입니다.
![image](https://github.com/Jangwoohyeok123/Economic-Context/assets/91610181/27687df5-1b95-4255-874e-a7d6ba7f1de5)
