### PR TITLE
feature: Morepage  skeleton UI 추가

### DIFF
--- a/src/components/charts/line/LineChart.module.scss
+++ b/src/components/charts/line/LineChart.module.scss
@@ -3,7 +3,6 @@
 	height: 100%;
 
 	.featuresWrap {
-		margin-top: 20px;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;

--- a/src/components/skeleton/Skeleton.module.scss
+++ b/src/components/skeleton/Skeleton.module.scss
@@ -1,0 +1,42 @@
+$skeletonBgColor: #e7e7e7;
+$skeletonBarColor: linear-gradient(to right, $skeletonBgColor 0%, #f0f0f0 50%, $skeletonBgColor 100%);
+@keyframes slide {
+	from {
+		left: 0%; /* 애니메이션 시작 위치 */
+	}
+	to {
+		left: 100%; /* 애니메이션 종료 위치 */
+	}
+}
+
+.Indicator {
+	width: 100%;
+	> div {
+		background-color: $skeletonBgColor;
+		border-radius: 5px;
+		position: relative;
+		overflow-x: hidden;
+		&::after {
+			content: '';
+			position: absolute;
+			display: block;
+			width: 30%;
+			height: 100%;
+			background: $skeletonBarColor;
+			animation: slide 2s linear infinite;
+			opacity: 0.6;
+			transform: skewX(-20deg);
+		}
+	}
+	.title {
+		height: 60px;
+		margin-bottom: 5px;
+	}
+	.chart {
+		height: 300px;
+		margin-bottom: 16px;
+	}
+	.description {
+		height: 200px;
+	}
+}

--- a/src/components/skeleton/SkeletonIndicatorCard.tsx
+++ b/src/components/skeleton/SkeletonIndicatorCard.tsx
@@ -1,0 +1,12 @@
+import clsx from 'clsx';
+import styles from './Skeleton.module.scss';
+
+export default function SkeletonIndicatorCard() {
+	return (
+		<div className={clsx(styles.Indicator)}>
+			<div className={clsx(styles.title)}></div>
+			<div className={clsx(styles.chart)}></div>
+			<div className={clsx(styles.description)}></div>
+		</div>
+	);
+}

--- a/src/components/skeleton/SkeletonLineChart.tsx
+++ b/src/components/skeleton/SkeletonLineChart.tsx
@@ -1,0 +1,6 @@
+import clsx from 'clsx';
+import styles from './Skeleton.module.scss';
+
+export default function SkeletonLineChart() {
+	return <div className={clsx(styles.ChartList)}></div>;
+}

--- a/src/components/skeleton/SkeletonMorepage.tsx
+++ b/src/components/skeleton/SkeletonMorepage.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import styles from './Skeleton.module.scss';
 
-export default function SkeletonIndicatorCard() {
+export default function SkeletonMorepage() {
 	return (
 		<div className={clsx(styles.Indicator)}>
 			<div className={clsx(styles.title)}></div>

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -16,6 +16,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import BubblePopButton from '@/components/bubblePopButton/BubblePopButton';
 import { addFavorite, deleteFavorite, getFavoriteCateogry_List } from '@/api/favorite';
 import { FavoriteIndicator_Type } from '@/types/favorite';
+import SkeletonIndicatorCard from '@/components/skeleton/SkeletonIndicatorCard';
 
 const DynamicAlertModal = dynamic(() => import('@/components/modals/alertModal/AlertModal'), { ssr: false });
 
@@ -150,22 +151,29 @@ export default function Morepage() {
 	return (
 		<>
 			<main className={clsx(styles.Morepage, poppins.variable, roboto.variable)}>
-				{chartDatas.length && indicator && (
-					<LineChart indicator={indicator} values={chartDatas} width={100} height={50}>
-						{user.isLogin ? (
-							<button className={isActive ? clsx(styles.on) : clsx('')} onClick={buttonHandler}>
-								{isActive ? 'delete' : 'save'}
-							</button>
-						) : (
-							<button onClick={buttonHandler}>save</button>
-						)}
-					</LineChart>
+				{!indicator.id ? (
+					<SkeletonIndicatorCard />
+				) : (
+					chartDatas.length &&
+					indicator && (
+						<>
+							<LineChart indicator={indicator} values={chartDatas} width={100} height={50}>
+								{user.isLogin ? (
+									<button className={isActive ? clsx(styles.on) : clsx('')} onClick={buttonHandler}>
+										{isActive ? 'delete' : 'save'}
+									</button>
+								) : (
+									<button onClick={buttonHandler}>save</button>
+								)}
+							</LineChart>
+							<ChartDescription indicator={indicator}>
+								<BubblePopButton clickHandler={buttonHandler} className={isActive ? clsx(styles.on) : ''}>
+									{isActive ? 'remove' : 'save'}
+								</BubblePopButton>
+							</ChartDescription>
+						</>
+					)
 				)}
-				<ChartDescription indicator={indicator}>
-					<BubblePopButton clickHandler={buttonHandler} className={isActive ? clsx(styles.on) : ''}>
-						{isActive ? 'remove' : 'save'}
-					</BubblePopButton>
-				</ChartDescription>
 			</main>
 			<DynamicAlertModal
 				isModalOpen={isAlertModalOpen}

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -16,7 +16,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import BubblePopButton from '@/components/bubblePopButton/BubblePopButton';
 import { addFavorite, deleteFavorite, getFavoriteCateogry_List } from '@/api/favorite';
 import { FavoriteIndicator_Type } from '@/types/favorite';
-import SkeletonIndicatorCard from '@/components/skeleton/SkeletonIndicatorCard';
+import SkeletonMorepage from '@/components/skeleton/SkeletonMorepage';
 
 const DynamicAlertModal = dynamic(() => import('@/components/modals/alertModal/AlertModal'), { ssr: false });
 
@@ -152,7 +152,7 @@ export default function Morepage() {
 		<>
 			<main className={clsx(styles.Morepage, poppins.variable, roboto.variable)}>
 				{!indicator.id ? (
-					<SkeletonIndicatorCard />
+					<SkeletonMorepage />
 				) : (
 					chartDatas.length &&
 					indicator && (

--- a/src/styles/Reset.scss
+++ b/src/styles/Reset.scss
@@ -14,7 +14,7 @@ body {
 
 // page 는 main 으로 시작해라
 main {
-	padding-top: 60px;
+	padding-top: 100px;
 	width: 80%;
 	margin: 0 auto;
 	color: var(--fontColor);


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- [x] 로딩 상황에서 스켈레톤UI를 노출합니다.
## PR 요약
- More page의 UI와 유사한 컴포넌트를 만들고, 애니메이션으로 loading중이라는 의미를 제공함.
- component/skeleton/Skeleton[컴포넌트이름] 의 파일구조.
- skeleton UI에 동일한 스타일링 및 애니메이션 재사용을 위한 파일 구조.

## ScreenShot (Optional)
![image](https://github.com/Jangwoohyeok123/Economic-Context/assets/70941333/dc1f9047-ccc3-4912-8483-5b7bb7df0bb7)
