### PR TITLE
feature: currentContext 페이지 ChartList SkeletonUI적용으로  사용성 개선

### DIFF
--- a/src/components/chartList/ChartList.tsx
+++ b/src/components/chartList/ChartList.tsx
@@ -5,6 +5,7 @@ import { getChartData, getIndicator } from '@/api/fred';
 import const_queryKey from '@/const/queryKey';
 import LineChart from '../charts/line/LineChart';
 import { DateAndValue_Type, Indicator_Type } from '@/types/fred';
+import SkeletonChartList from '../skeleton/SkeletonChartList';
 
 interface ChartSwiper_Props {
 	seriesIds: string[];
@@ -46,7 +47,9 @@ export default function ChartList({ seriesIds }: ChartSwiper_Props) {
 
 	return (
 		<div className={clsx(styles.ChartList)}>
-			{!isLoading &&
+			{isLoading ? (
+				<SkeletonChartList />
+			) : (
 				chartDatasForList.length > 0 &&
 				chartDatasForList.map((chartData, index: number) => {
 					const { indicator, values } = chartData;
@@ -56,7 +59,8 @@ export default function ChartList({ seriesIds }: ChartSwiper_Props) {
 							<LineChart indicator={indicator} values={values} width={100} height={30} className={'ChartList'} />
 						</div>
 					);
-				})}
+				})
+			)}
 		</div>
 	);
 }

--- a/src/components/skeleton/Skeleton.module.scss
+++ b/src/components/skeleton/Skeleton.module.scss
@@ -1,5 +1,7 @@
+@use '../../styles/Variable' as var;
 $skeletonBgColor: #e7e7e7;
 $skeletonBarColor: linear-gradient(to right, $skeletonBgColor 0%, #f0f0f0 50%, $skeletonBgColor 100%);
+
 @keyframes slide {
 	from {
 		left: 0%; /* 애니메이션 시작 위치 */
@@ -38,5 +40,51 @@ $skeletonBarColor: linear-gradient(to right, $skeletonBgColor 0%, #f0f0f0 50%, $
 	}
 	.description {
 		height: 200px;
+	}
+}
+
+.ChartList {
+	width: 100%;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	align-items: flex-start;
+	padding: 10px 0px 40px;
+	gap: 0 2%;
+	> div {
+		width: 32%;
+		height: 280px;
+		background-color: $skeletonBgColor;
+		border-radius: 5px;
+		position: relative;
+		overflow-x: hidden;
+		&::after {
+			content: '';
+			position: absolute;
+			display: block;
+			width: 30%;
+			height: 100%;
+			background: $skeletonBarColor;
+			animation: slide 2s linear infinite;
+			opacity: 0.6;
+			transform: skewX(-20deg);
+		}
+	}
+}
+@media screen and (max-width: var.$tablet) {
+	.ChartList {
+		gap: 0 2%;
+		.Chart {
+			width: 49%;
+			height: fit-content;
+		}
+	}
+}
+@media screen and (max-width: var.$mobile) {
+	.ChartList {
+		gap: 0%;
+		.Chart {
+			width: 100%;
+		}
 	}
 }

--- a/src/components/skeleton/SkeletonChartList.tsx
+++ b/src/components/skeleton/SkeletonChartList.tsx
@@ -1,0 +1,12 @@
+import clsx from 'clsx';
+import styles from './Skeleton.module.scss';
+
+export default function SkeletonChartList() {
+	return (
+		<div className={clsx(styles.ChartList)}>
+			<div className={clsx(styles.Chart)}></div>
+			<div className={clsx(styles.Chart)}></div>
+			<div className={clsx(styles.Chart)}></div>
+		</div>
+	);
+}


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- currentContext 페이지 사용성 개선

## PR 요약
- useQueries요청에서 각 쿼리의 로딩 상태를 점검하는 로직을 추가하였습니다.
- 모든 쿼리요청의 loading이 완료될 떄까지 스켈레톤 UI가 노출됩니다.

## ScreenShot (Optional)
![image](https://github.com/Jangwoohyeok123/Economic-Context/assets/70941333/92e7f83e-335b-446a-b286-16bcc669bd9f)
