### PR TITLE
Feature/indicator card

### DIFF
--- a/src/components/bubblePopButton/BubblePopButton.module.scss
+++ b/src/components/bubblePopButton/BubblePopButton.module.scss
@@ -1,2 +1,4 @@
 .BubblePopButton {
+	border: none;
+	background: #fff;
 }

--- a/src/components/bubblePopButton/BubblePopButton.tsx
+++ b/src/components/bubblePopButton/BubblePopButton.tsx
@@ -1,5 +1,4 @@
-import clsx from 'clsx';
-import styles from './BubblePopButton.module.scss';
+import styled from 'styled-components';
 
 interface BubblePopButton_Props {
 	children?: React.ReactNode;
@@ -7,19 +6,26 @@ interface BubblePopButton_Props {
 	clickHandler: () => void;
 }
 
+const Button = styled.button`
+	border: none;
+	background: #fff;
+	width: 100%;
+	height: 100%;
+`;
+
 export default function BubblePopButton({ children, className, clickHandler: onClick }: BubblePopButton_Props) {
 	const bubblePop = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
 		event.stopPropagation();
 	};
 
 	return (
-		<button
-			className={(clsx(styles.BubblePopButton), className)}
+		<Button
+			className={className}
 			onClick={event => {
 				bubblePop(event);
 				onClick();
 			}}>
 			{children}
-		</button>
+		</Button>
 	);
 }

--- a/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
+++ b/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { getChartData } from '@/api/fred';
 import styled from 'styled-components';
 import getVolatility from '@/utils/getVolatility';
+import { FavoriteIndicator_Type } from '@/types/favorite';
 
 interface IndicatorCardWrapper_Props {
 	volatility: number;
@@ -53,9 +54,9 @@ const IndicatorCardWrapper = styled.div<IndicatorCardWrapper_Props>`
 	}
 `;
 
-interface IndicatorCard_Props {
+interface FavoriteIndicatorCard_Props {
 	categoryId: number;
-	indicator: Indicator_Type;
+	favoriteIndicator: FavoriteIndicator_Type;
 	children: React.ReactNode;
 	className?: string;
 	currentPage: number;
@@ -69,8 +70,8 @@ interface IndicatorCard_Props {
  * @param observation_start
  * @returns title, 기간 정보가 담기 card 를 반환한다. className 을 통해 커스텀 가능하다.
  */
-export default function IndicatorCard({ indicator, categoryId, children, className, currentPage }: IndicatorCard_Props) {
-	const { title, id: seriesId, observation_start, observation_end, notes } = indicator;
+export default function FavoriteIndicatorCard({ favoriteIndicator, categoryId, children, className, currentPage }: FavoriteIndicatorCard_Props) {
+	const { title, seriesId, observation_start, observation_end, notes } = favoriteIndicator;
 	const router = useRouter();
 	const cleandTitle = title ? cleanString(title) : 'title';
 	const routeMorePage = (seriesId: string) => router.push(`${frontUrl}/${seriesId}?title=${cleandTitle}&categoryId=${categoryId}`);
@@ -99,7 +100,7 @@ export default function IndicatorCard({ indicator, categoryId, children, classNa
 					<div className='values'>
 						<span>{lastData}</span>
 						<span>{volatility >= 0 ? `(+${volatility}%)` : `(${volatility}%)`}</span>
-						<div>last_updated: {indicator.observation_end}</div>
+						<div>last_updated: {favoriteIndicator.observation_end}</div>
 					</div>
 				</div>
 			</div>

--- a/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
+++ b/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
@@ -18,10 +18,8 @@ const IndicatorCardWrapper = styled.div<IndicatorCardWrapper_Props>`
 		padding: 20px;
 		background: #fff;
 		display: flex;
-		/* padding-top: 20px; */
 		justify-content: space-between;
 		align-items: top;
-		/* height: 200px; */
 
 		h3 {
 			font-weight: 400;

--- a/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
+++ b/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
@@ -15,13 +15,13 @@ interface IndicatorCardWrapper_Props {
 
 const IndicatorCardWrapper = styled.div<IndicatorCardWrapper_Props>`
 	.notChart {
-		padding: 0 20px;
+		padding: 20px;
 		background: #fff;
 		display: flex;
-		padding-top: 20px;
+		/* padding-top: 20px; */
 		justify-content: space-between;
 		align-items: top;
-		height: 130px;
+		/* height: 200px; */
 
 		h3 {
 			font-weight: 400;

--- a/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
+++ b/src/components/cards/favoriteIndicatorCard/FavoriteIndicatorCard.tsx
@@ -90,7 +90,7 @@ export default function FavoriteIndicatorCard({ favoriteIndicator, categoryId, c
 
 	return (
 		<IndicatorCardWrapper volatility={volatility}>
-			<LineChart categoryId={categoryId} values={chartDatas} width={100} height={40} duration={1} />
+			<LineChart categoryId={categoryId} values={chartDatas} width={100} height={40} />
 			<div className={'notChart ' + className}>
 				<h3>{title}</h3>
 				<div className='right'>

--- a/src/components/cards/indicatorCard/IndicatorCard.tsx
+++ b/src/components/cards/indicatorCard/IndicatorCard.tsx
@@ -91,7 +91,7 @@ export default function IndicatorCard({ indicator, categoryId, children, classNa
 
 	return (
 		<IndicatorCardWrapper volatility={volatility}>
-			<LineChart categoryId={categoryId} values={chartDatas} width={100} height={40} duration={1} />
+			<LineChart categoryId={categoryId} values={chartDatas} width={100} height={40} />
 			<div className={'notChart ' + className}>
 				<h3>{title}</h3>
 				<div className='right'>

--- a/src/components/category/Category.module.scss
+++ b/src/components/category/Category.module.scss
@@ -4,7 +4,7 @@
 	padding-top: 50px;
 	display: grid;
 	grid-template-columns: 47% 47%;
-	grid-auto-rows: 380px;
+	grid-auto-rows: 520px;
 	justify-content: space-between;
 	row-gap: 50px;
 }
@@ -14,7 +14,7 @@
 		width: 100%;
 		margin: 0 auto;
 		grid-template-columns: 47% 47%;
-		grid-auto-rows: 400px;
+		grid-auto-rows: 520px;
 	}
 }
 
@@ -22,8 +22,8 @@
 	.Category {
 		width: 100%;
 		margin: 0 auto;
-		grid-template-columns: 47% 47%;
-		grid-auto-rows: 400px;
+		grid-template-columns: 100%;
+		grid-auto-rows: 520px;
 	}
 }
 @media screen and (max-width: var.$mobile) {
@@ -31,6 +31,6 @@
 		width: 80%;
 		margin: 0 auto;
 		grid-template-columns: 100%;
-		grid-auto-rows: 400px;
+		grid-auto-rows: 520px;
 	}
 }

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -20,6 +20,7 @@ const StarCotainer = styled.div`
 	.star {
 		width: 25px;
 		height: 100%;
+		cursor: pointer;
 	}
 `;
 

--- a/src/components/category/Category.tsx
+++ b/src/components/category/Category.tsx
@@ -4,6 +4,7 @@ import { Indicator_Type } from '@/types/fred';
 import IndicatorCard from '../cards/indicatorCard/IndicatorCard';
 import BubblePopButton from '../bubblePopButton/BubblePopButton';
 import { FaRegStar } from 'react-icons/fa6';
+import styled from 'styled-components';
 
 interface Category_Props {
 	categoryData: Indicator_Type[];
@@ -12,6 +13,15 @@ interface Category_Props {
 	categoryId: number;
 	setIsAlertModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
+
+const StarCotainer = styled.div`
+	height: 30px;
+
+	.star {
+		width: 25px;
+		height: 100%;
+	}
+`;
 
 export default function Category({ categoryData, currentPage, itemsPerPage, categoryId, setIsAlertModalOpen }: Category_Props) {
 	return (
@@ -23,7 +33,9 @@ export default function Category({ categoryData, currentPage, itemsPerPage, cate
 							clickHandler={() => {
 								setIsAlertModalOpen(true);
 							}}>
-							<FaRegStar />
+							<StarCotainer>
+								<FaRegStar className='star' />
+							</StarCotainer>
 						</BubblePopButton>
 					</IndicatorCard>
 				);

--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.module.scss
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.module.scss
@@ -2,22 +2,4 @@
 
 .CategoryWithIsActive {
 	@extend .Category;
-
-	button {
-		width: 100%;
-		height: 50px;
-		border: none;
-		cursor: pointer;
-		transition: 0.2s;
-
-		&:hover {
-			color: #fff;
-			background: #111;
-		}
-
-		&.on {
-			color: #fff;
-			background: #111;
-		}
-	}
 }

--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
@@ -32,6 +32,7 @@ const StarCotainer = styled.div`
 		height: 100%;
 		fill: #dddddd;
 		transition: 0.2s;
+		cursor: pointer;
 	}
 
 	.activeStar {

--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
@@ -14,6 +14,7 @@ import { FavoriteIndicatorWithIsActive_Type, FavoriteIndicator_Type } from '@/ty
 import FavoriteIndicatorCard from '../cards/favoriteIndicatorCard/FavoriteIndicatorCard';
 import styled from 'styled-components';
 import { FaRegStar } from 'react-icons/fa6';
+import { FaStar } from 'react-icons/fa6';
 
 interface CategoryWithIsActive_Props {
 	categoryData: Indicator_Type[];
@@ -24,10 +25,17 @@ interface CategoryWithIsActive_Props {
 
 const StarCotainer = styled.div`
 	height: 30px;
+	transition: 0.3s;
 
 	.star {
-		width: 25px;
+		width: 30px;
 		height: 100%;
+		fill: #dddddd;
+		transition: 0.2s;
+	}
+
+	.activeStar {
+		fill: var(--yellowColor);
 	}
 `;
 
@@ -105,7 +113,7 @@ export default function CategoryWithIsActive({ categoryData, currentPage, itemsP
 									});
 								}}>
 								<StarCotainer>
-									<FaRegStar className='star' />
+									<FaStar className={clsx('star', isActive ? 'activeStar' : '')} />
 								</StarCotainer>
 							</BubblePopButton>
 						</FavoriteIndicatorCard>

--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
@@ -72,21 +72,11 @@ export default function CategoryWithIsActive({ categoryData, currentPage, itemsP
 		<section className={clsx(styles.CategoryWithIsActive)}>
 			{categoryWithIsActive
 				.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage)
-				.map((series: FavoriteIndicatorWithIsActive_Type, idx: number) => {
-					const { title, seriesId, frequency, popularity, observation_start, observation_end, isActive } = series;
-					const notes = series.notes ?? '';
+				.map((seriess: FavoriteIndicatorWithIsActive_Type, idx: number) => {
+					const { title, seriesId, frequency, popularity, observation_start, observation_end, isActive } = seriess;
+					const notes = seriess.notes ?? '';
 					return (
-						<IndicatorCard
-							key={idx}
-							title={title}
-							seriesId={seriesId}
-							categoryId={categoryId}
-							frequency={frequency as string}
-							popularity={popularity as number}
-							notes={notes}
-							observation_end={observation_end as string}
-							observation_start={observation_start as string}
-							className={styles.IndicatorCard}>
+						<IndicatorCard key={idx} categoryId={categoryId} indicator={seriess} currentPage={currentPage} className={styles.IndicatorCard}>
 							<BubblePopButton
 								className={clsx(isActive ? styles.on : '')}
 								clickHandler={() => {

--- a/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
+++ b/src/components/categoryWithIsAcitve/CategoryWithIsActive.tsx
@@ -11,6 +11,9 @@ import { Store_Type } from '@/types/redux';
 import useFavoriteMutation from '@/hooks/useFavoriteMutation';
 import { getFavoriteCateogry_List } from '@/api/favorite';
 import { FavoriteIndicatorWithIsActive_Type, FavoriteIndicator_Type } from '@/types/favorite';
+import FavoriteIndicatorCard from '../cards/favoriteIndicatorCard/FavoriteIndicatorCard';
+import styled from 'styled-components';
+import { FaRegStar } from 'react-icons/fa6';
 
 interface CategoryWithIsActive_Props {
 	categoryData: Indicator_Type[];
@@ -18,6 +21,15 @@ interface CategoryWithIsActive_Props {
 	itemsPerPage: number;
 	categoryId: number;
 }
+
+const StarCotainer = styled.div`
+	height: 30px;
+
+	.star {
+		width: 25px;
+		height: 100%;
+	}
+`;
 
 export default function CategoryWithIsActive({ categoryData, currentPage, itemsPerPage, categoryId }: CategoryWithIsActive_Props) {
 	const user = useSelector((state: Store_Type) => state.user);
@@ -76,7 +88,12 @@ export default function CategoryWithIsActive({ categoryData, currentPage, itemsP
 					const { title, seriesId, frequency, popularity, observation_start, observation_end, isActive } = seriess;
 					const notes = seriess.notes ?? '';
 					return (
-						<IndicatorCard key={idx} categoryId={categoryId} indicator={seriess} currentPage={currentPage} className={styles.IndicatorCard}>
+						<FavoriteIndicatorCard
+							key={idx}
+							categoryId={categoryId}
+							favoriteIndicator={seriess}
+							currentPage={currentPage}
+							className={styles.IndicatorCard}>
 							<BubblePopButton
 								className={clsx(isActive ? styles.on : '')}
 								clickHandler={() => {
@@ -87,9 +104,11 @@ export default function CategoryWithIsActive({ categoryData, currentPage, itemsP
 										});
 									});
 								}}>
-								{isActive ? 'remove' : 'save'}
+								<StarCotainer>
+									<FaRegStar className='star' />
+								</StarCotainer>
 							</BubblePopButton>
-						</IndicatorCard>
+						</FavoriteIndicatorCard>
 					);
 				})}
 		</section>

--- a/src/components/chartList/ChartList.tsx
+++ b/src/components/chartList/ChartList.tsx
@@ -9,10 +9,11 @@ import SkeletonChartList from '../skeleton/SkeletonChartList';
 
 interface ChartSwiper_Props {
 	seriesIds: string[];
+	categoryIds: number[];
 }
 
 /** context data 가 넘어왔을 때 */
-export default function ChartList({ seriesIds }: ChartSwiper_Props) {
+export default function ChartList({ seriesIds, categoryIds }: ChartSwiper_Props) {
 	const queryChartValuesResults = useQueries({
 		queries: seriesIds.map(seriesId => ({
 			queryKey: [const_queryKey.context, seriesId],
@@ -55,7 +56,7 @@ export default function ChartList({ seriesIds }: ChartSwiper_Props) {
 
 					return (
 						<div key={index} className={clsx(styles.Chart)}>
-							<LineChart indicator={indicator} values={values} width={100} height={30} className={'ChartList'} duration={3} />
+							<LineChart categoryId={categoryIds[index]} values={values} width={100} height={30} className='ChartList' />
 						</div>
 					);
 				})

--- a/src/components/chartSwiper/ChartSwiper.tsx
+++ b/src/components/chartSwiper/ChartSwiper.tsx
@@ -62,7 +62,7 @@ export default function ChartSwiper({ seriesIds }: ChartSwiper_Props) {
 						return (
 							<SwiperSlide key={index}>
 								{/* 구조변경 전 default 값으로 처리 */}
-								<LineChart categoryId={const_categoryId.interest_fed} duration={3} indicator={indicator} values={values} />
+								<LineChart categoryId={const_categoryId.interest_fed} values={values} />
 							</SwiperSlide>
 						);
 					})}

--- a/src/components/charts/line/LineChart.tsx
+++ b/src/components/charts/line/LineChart.tsx
@@ -69,7 +69,6 @@ const Svg = styled.svg`
 
 export interface LineChart_Props {
 	categoryId: number;
-	duration: number;
 	children?: React.ReactElement;
 	height?: number;
 	width?: number;
@@ -78,8 +77,8 @@ export interface LineChart_Props {
 }
 
 /**
- * @indicator SeriessType
- * @values Value[]
+ * @categoryId number
+ * @values DateAndValue_Type[]
  * @height [x]vh
  * @width [y]%
  * @className

--- a/src/components/charts/line/LineChart.tsx
+++ b/src/components/charts/line/LineChart.tsx
@@ -69,7 +69,6 @@ const Svg = styled.svg`
 
 export interface LineChart_Props {
 	categoryId: number;
-	indicator: Indicator_Type;
 	duration: number;
 	children?: React.ReactElement;
 	height?: number;
@@ -85,7 +84,7 @@ export interface LineChart_Props {
  * @width [y]%
  * @className
  */
-const LineChart = ({ categoryId, indicator, values: values_List, width = 100, height = 65, className }: LineChart_Props) => {
+const LineChart = ({ categoryId, values: values_List, width = 100, height = 65, className }: LineChart_Props) => {
 	const rootSvgRef = useRef<SVGSVGElement>(null);
 	const rootSvgContainerRef = useRef<HTMLDivElement>(null);
 	const [duration, setDuration] = useState<number>(10);

--- a/src/components/currentContext/CurrentContext.tsx
+++ b/src/components/currentContext/CurrentContext.tsx
@@ -20,15 +20,17 @@ export default function CurrentContext({ currentContextId }: CurrentContext_Prop
 
 	if (isLoading) return <div>Loading...</div>;
 
-	const seriesIds = currentContext?.customIndicators.map((indicator: FavoriteIndicator_Type) => {
-		return indicator.seriesId;
+	const [seriesIds, categoryIds]: [string[], number[]] = [[], []];
+	currentContext?.customIndicators.forEach((indicator: FavoriteIndicator_Type) => {
+		seriesIds.push(indicator.seriesId);
+		categoryIds.push(indicator.categoryId);
 	});
 
 	return (
 		<section className={clsx(styles.CurrentContext)}>
 			<h2>Context Chart List</h2>
 			{/* {seriesIds && <ChartSwiper seriesIds={seriesIds} />} */}
-			{seriesIds && <ChartList seriesIds={seriesIds} />}
+			{seriesIds && categoryIds && <ChartList seriesIds={seriesIds} categoryIds={categoryIds} />}
 		</section>
 	);
 }

--- a/src/components/journalsSection/journalForm/JournalForm.tsx
+++ b/src/components/journalsSection/journalForm/JournalForm.tsx
@@ -201,7 +201,6 @@ export default function JournalForm({
 			queryClient.invalidateQueries({
 				queryKey: [const_queryKey.journal, contextId]
 			});
-			alert('add 성공');
 		},
 		onError(error) {
 			console.error(error);
@@ -214,7 +213,7 @@ export default function JournalForm({
 			addJournalMutation.mutate({ userId, contextId, journalDataParams });
 			// setIsWrite(false);
 		} else {
-			alert('모두 작성해주세요.');
+			// alert('모두 작성해주세요.');
 		}
 	};
 	interface ContextType {

--- a/src/components/modals/makeContextModal/MakeContextModal.tsx
+++ b/src/components/modals/makeContextModal/MakeContextModal.tsx
@@ -55,7 +55,7 @@ export default function MakeContextModal({ favorites, isModalOpen, setIsModalOpe
 		) {
 			addContextMutation.mutate(favoritesForContext);
 		} else {
-			alert('title 이 중복됩니다.');
+			// alert('title 이 중복됩니다.');
 		}
 	};
 

--- a/src/hooks/useFavoriteMutation.tsx
+++ b/src/hooks/useFavoriteMutation.tsx
@@ -16,7 +16,7 @@ export default function useFavoriteMutation(categoryId?: number) {
 				queryKey: [const_queryKey.favorite]
 			});
 
-			alert('add 성공');
+			// alert('add 성공');
 		},
 		onError(error) {
 			console.error(error);
@@ -29,7 +29,7 @@ export default function useFavoriteMutation(categoryId?: number) {
 			queryClient.invalidateQueries({
 				queryKey: [const_queryKey.favorite]
 			});
-			alert('delete 성공');
+			// alert('delete 성공');
 		},
 		onError(error) {
 			console.error(error);
@@ -43,7 +43,7 @@ export default function useFavoriteMutation(categoryId?: number) {
 				queryKey: [const_queryKey.favorite, categoryId]
 			});
 
-			alert('add 성공');
+			// alert('add 성공');
 		},
 		onError(error) {
 			console.error(error);
@@ -56,14 +56,12 @@ export default function useFavoriteMutation(categoryId?: number) {
 			queryClient.invalidateQueries({
 				queryKey: [const_queryKey.favorite, categoryId]
 			});
-			alert('delete 성공');
+			// alert('delete 성공');
 		},
 		onError(error) {
 			console.error(error);
 		}
 	});
 
-	return categoryId
-		? { addFavoriteMutation, deleteFavoriteMutation }
-		: { addFavoriteMutationAll, deleteFavoriteMutationAll };
+	return categoryId ? { addFavoriteMutation, deleteFavoriteMutation } : { addFavoriteMutationAll, deleteFavoriteMutationAll };
 }

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -242,7 +242,7 @@ export default function Morepage() {
 							</SaveFavoriteIndicatorButton>
 						</IntroduceContainer>
 
-						<LineChart categoryId={Number(categoryId as string)} duration={10} indicator={indicator} values={chartDatas} width={100}></LineChart>
+						<LineChart categoryId={Number(categoryId as string)} values={chartDatas} width={100}></LineChart>
 						<ChartDescription indicator={indicator}></ChartDescription>
 						<AnotherIndicators />
 					</>

--- a/src/styles/Global.scss
+++ b/src/styles/Global.scss
@@ -15,4 +15,5 @@
 	--headerSize: 60px;
 	--chartHeaderSize: 25px;
 	--chartPadding: 20px;
+	--yellowColor: #f7e704;
 }


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- IndicatorCard 를 수정했습니다. 

## PR 요약
- 기존방식은 IndicatorCard가 Indicator_Type, FavoriteIndicatorWithIsActive_Type의 데이터를 전달받기위해서 props 가 너무 많은 문제점이 있었습니다. 
- 컴포넌트를 FavoriteIndicatorCard, IndicatorCard로 분리하고 props로 객체를 전달받는 형식으로 바꿔 좀 더 명확히 컴포넌트가 사용하는 데이터를 구별할 수 있게 수정됐다고 생각합니다.

- Union 타입을 이용할 까 생각해봤지만 컴포넌트 분리하는게 좀 더 명확하다고 판단했는데 이에대해서 의견이 궁금합니다.

## ScreenShot (Optional)
