### PR TITLE
fix: 이벤트 핸들러에서 예외처리

### DIFF
--- a/src/utils/renderChartSvg.ts
+++ b/src/utils/renderChartSvg.ts
@@ -138,10 +138,12 @@ export default function renderChartSvg(svg: SVGElement, periodValues_List: DateA
 			.attr('height', svgHeight - 50 - xAxisHeight)
 			.attr('opacity', 0)
 			.on('mouseover', function (event, d) {
+				if (!tooltipElement) return;
 				tooltipElement.style.visibility = 'visible';
 				updateTooltipContent(d);
 			})
 			.on('mousemove', function (event, d) {
+				if (!tooltipElement) return;
 				const tooltipX = utcScale(d.date);
 				const tooltipY = linearScale(Number(d.value));
 
@@ -150,6 +152,7 @@ export default function renderChartSvg(svg: SVGElement, periodValues_List: DateA
 				tooltipElement.style.transform = 'translate(-30%, -50%)';
 			})
 			.on('mouseout', function () {
+				if (!tooltipElement) return;
 				tooltipElement.style.visibility = 'hidden';
 			});
 	}


### PR DESCRIPTION
## 브랜치의 목적 및 상황
- tooltip 이벤트 핸들러 예외처리가 안될때 예외처리함 

## PR 요약
- LineChart 컴포넌트의 이벤트 핸들러의 if (!tooltipElement) return; 추가


## ScreenShot (Optional)
